### PR TITLE
fix: keep selected row state when data changes in Table component

### DIFF
--- a/src/components/Table/helpers/rows/computeUniqueRowKey.js
+++ b/src/components/Table/helpers/rows/computeUniqueRowKey.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import getFieldValue from './getFieldValue';
 
 let rowIndex = 0;
@@ -6,6 +7,9 @@ export default function computeUniqueRowKey(rowData, keyField) {
     const value = getFieldValue(rowData, keyField);
     if (value && typeof value === 'string') {
         return value;
+    }
+    if (rowIndex === 0) {
+        console.error('The "keyField" passed is not valid.');
     }
     rowIndex += 1;
     return `row-${rowIndex}`;

--- a/src/components/Table/helpers/selector/__test__/getSelectedRowKeysFromSelectedRows.spec.js
+++ b/src/components/Table/helpers/selector/__test__/getSelectedRowKeysFromSelectedRows.spec.js
@@ -1,0 +1,29 @@
+import getSelectedRowKeysFromSelectedRows from '../getSelectedRowKeysFromSelectedRows';
+
+describe('getSelectedRowKeysFromSelectedRows', () => {
+    it('should return an empty object when no argument is passed', () => {
+        expect(getSelectedRowKeysFromSelectedRows()).toEqual({});
+    });
+    it('should return an empty object when selectedRows passed are not valid', () => {
+        const selectedRows = ['wrongKey'];
+        const indexes = {
+            qwerty1234: true,
+            asdfgh1234: true,
+        };
+        expect(getSelectedRowKeysFromSelectedRows(selectedRows, indexes)).toEqual({});
+    });
+    it('should return the right selectedRowKeys', () => {
+        const selectedRows = ['qwerty1234', 'wrongKey'];
+        const indexes = {
+            qwerty1234: {
+                rowIndex: 0,
+            },
+            asdfgh1234: {
+                rowIndex: 1,
+            },
+        };
+        expect(getSelectedRowKeysFromSelectedRows(selectedRows, indexes)).toEqual({
+            qwerty1234: true,
+        });
+    });
+});

--- a/src/components/Table/helpers/selector/getSelectedRowKeys.js
+++ b/src/components/Table/helpers/selector/getSelectedRowKeys.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-param-reassign */
+import getFieldValue from '../rows/getFieldValue';
+
+export default function getSelectedRowKeys(selectedRows, keyField) {
+    return selectedRows.reduce((selectedRowsKeys, row) => {
+        const key = getFieldValue(row, keyField);
+        selectedRowsKeys[key] = true;
+        return selectedRowsKeys;
+    }, {});
+}

--- a/src/components/Table/helpers/selector/getSelectedRowKeysFromSelectedRows.js
+++ b/src/components/Table/helpers/selector/getSelectedRowKeysFromSelectedRows.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-param-reassign */
+
+export default function getSelectedRowKeysFromSelectedRows(selectedRows = [], indexes = {}) {
+    return selectedRows.reduce((selectedRowsKeys, key) => {
+        if (indexes[key]) {
+            selectedRowsKeys[key] = true;
+        }
+        return selectedRowsKeys;
+    }, {});
+}

--- a/src/components/Table/helpers/selector/index.js
+++ b/src/components/Table/helpers/selector/index.js
@@ -5,6 +5,8 @@ import getUpdatedRowsWhenDeselectAll from './getUpdatedRowsWhenDeselectAll';
 import getBulkSelectionState from './getBulkSelectionState';
 import getRowsWithInitalSelectedRows from './getRowsWithInitalSelectedRows';
 import isValidMaxRowSelection from './isValidMaxRowSelection';
+import getSelectedRowKeys from './getSelectedRowKeys';
+import getSelectedRowKeysFromSelectedRows from './getSelectedRowKeysFromSelectedRows';
 
 export {
     getUpdatedRowsWhenSelect,
@@ -14,4 +16,6 @@ export {
     getBulkSelectionState,
     getRowsWithInitalSelectedRows,
     isValidMaxRowSelection,
+    getSelectedRowKeys,
+    getSelectedRowKeysFromSelectedRows,
 };

--- a/src/components/Table/helpers/selector/isDisabledRow.js
+++ b/src/components/Table/helpers/selector/isDisabledRow.js
@@ -3,7 +3,7 @@ import getCurrentSelectionLength from './getCurrentSelectionLength';
 
 export default function isDisabledRow(params = {}) {
     const { rowKeyValue, maxRowSelection, selectedRowsKeys = {} } = params;
-    if (!isSelectedRow(rowKeyValue, selectedRowsKeys)) {
+    if (!isSelectedRow(selectedRowsKeys, rowKeyValue)) {
         return (
             maxRowSelection !== 1 && getCurrentSelectionLength(selectedRowsKeys) === maxRowSelection
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #762 

Changes proposed in this PR:
- keep selected row state when data changes and keep sync with onRowSelection in Table component


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
