### PR TITLE
styles: when selcted day styles in calendar

### DIFF
--- a/src/components/Calendar/styles.css
+++ b/src/components/Calendar/styles.css
@@ -63,7 +63,7 @@
   line-height: 36px;
   height: 36px;
   width: 36px;
-  margin: auto;
+  margin: 6px auto;
   padding: 0;
   border: none;
   outline: none; }

--- a/src/components/Calendar/styles.scss
+++ b/src/components/Calendar/styles.scss
@@ -82,7 +82,7 @@
     line-height: 36px;
     height: 36px;
     width: 36px;
-    margin: auto;
+    margin: 6px auto;
     padding: 0;
     border: none;
     outline: none;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #771

Changes proposed in this PR:
- fix styles when the day is selected in Calendar component


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
