### PR TITLE
feat: add searchIcon prop to lookup component

### DIFF
--- a/src/components/Lookup/__test__/rightElement.spec.js
+++ b/src/components/Lookup/__test__/rightElement.spec.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import RightElement from '../rightElement';
-import SearchIcon from '../icons/searchIcon';
-import CloseIcon from '../icons/closeIcon';
 
 describe('<RightElement />', () => {
     it('should render an icon container', () => {
@@ -18,13 +16,5 @@ describe('<RightElement />', () => {
         const component = mount(<RightElement showCloseButton onClear={onClearMockFn} />);
         component.find('ButtonIcon').simulate('click');
         expect(onClearMockFn).toHaveBeenCalledTimes(1);
-    });
-    it('should render an icon container with custom icon', () => {
-        const component = mount(<RightElement icon={<CloseIcon />} />);
-        expect(component.find('span.rainbow-lookup_input-icon').exists()).toBe(true);
-    });
-    it('should render an icon container with custom closeIcon', () => {
-        const component = mount(<RightElement closeIcon={<SearchIcon />} />);
-        expect(component.find('span.rainbow-lookup_input-icon').exists()).toBe(true);
     });
 });

--- a/src/components/Lookup/__test__/rightElement.spec.js
+++ b/src/components/Lookup/__test__/rightElement.spec.js
@@ -20,7 +20,7 @@ describe('<RightElement />', () => {
         expect(onClearMockFn).toHaveBeenCalledTimes(1);
     });
     it('should render an icon container with custom icon', () => {
-        const component = mount(<RightElement searchIcon={<CloseIcon />} />);
+        const component = mount(<RightElement icon={<CloseIcon />} />);
         expect(component.find('span.rainbow-lookup_input-icon').exists()).toBe(true);
     });
     it('should render an icon container with custom closeIcon', () => {

--- a/src/components/Lookup/__test__/rightElement.spec.js
+++ b/src/components/Lookup/__test__/rightElement.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import RightElement from '../rightElement';
+import SearchIcon from '../icons/searchIcon';
+import CloseIcon from '../icons/closeIcon';
 
 describe('<RightElement />', () => {
     it('should render an icon container', () => {
@@ -16,5 +18,13 @@ describe('<RightElement />', () => {
         const component = mount(<RightElement showCloseButton onClear={onClearMockFn} />);
         component.find('ButtonIcon').simulate('click');
         expect(onClearMockFn).toHaveBeenCalledTimes(1);
+    });
+    it('should render an icon container with custom icon', () => {
+        const component = mount(<RightElement searchIcon={<CloseIcon />} />);
+        expect(component.find('span.rainbow-lookup_input-icon').exists()).toBe(true);
+    });
+    it('should render an icon container with custom closeIcon', () => {
+        const component = mount(<RightElement closeIcon={<SearchIcon />} />);
+        expect(component.find('span.rainbow-lookup_input-icon').exists()).toBe(true);
     });
 });

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -18,6 +18,8 @@ import {
 import { uniqueId } from '../../libs/utils';
 import { UP_KEY, DOWN_KEY, ENTER_KEY, ESCAPE_KEY } from '../../libs/constants';
 import withReduxForm from '../../libs/hocs/withReduxForm';
+import SearchIcon from './icons/searchIcon';
+import CloseIcon from './icons/closeIcon';
 import './styles.css';
 
 const OPTION_HEIGHT = 48;
@@ -327,7 +329,8 @@ class Lookup extends Component {
             name,
             hideLabel,
             isLoading,
-            searchIcon,
+            icon,
+            closeIcon,
         } = this.props;
         const { searchValue, focusedItemIndex, options } = this.state;
         const chipOnDelete = disabled || readOnly ? undefined : this.handleRemoveValue;
@@ -369,7 +372,8 @@ class Lookup extends Component {
                         <RightElement
                             showCloseButton={!!searchValue}
                             onClear={this.clearInput}
-                            searchIcon={searchIcon}
+                            searchIcon={icon}
+                            closeIcon={closeIcon}
                         />
                         <Spinner
                             isVisible={isLoading}
@@ -483,7 +487,9 @@ Lookup.propTypes = {
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
     /** The icon to show when search is empty. */
-    searchIcon: PropTypes.object,
+    icon: PropTypes.object,
+    /** The icon to show when value is not empty. */
+    closeIcon: PropTypes.object,
 };
 
 Lookup.defaultProps = {
@@ -507,7 +513,8 @@ Lookup.defaultProps = {
     options: undefined,
     onSearch: () => {},
     debounce: false,
-    searchIcon: undefined,
+    icon: <SearchIcon />,
+    closeIcon: <CloseIcon />,
 };
 
 export default withReduxForm(Lookup);

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -19,7 +19,6 @@ import { uniqueId } from '../../libs/utils';
 import { UP_KEY, DOWN_KEY, ENTER_KEY, ESCAPE_KEY } from '../../libs/constants';
 import withReduxForm from '../../libs/hocs/withReduxForm';
 import SearchIcon from './icons/searchIcon';
-import CloseIcon from './icons/closeIcon';
 import './styles.css';
 
 const OPTION_HEIGHT = 48;
@@ -330,7 +329,6 @@ class Lookup extends Component {
             hideLabel,
             isLoading,
             icon,
-            closeIcon,
         } = this.props;
         const { searchValue, focusedItemIndex, options } = this.state;
         const chipOnDelete = disabled || readOnly ? undefined : this.handleRemoveValue;
@@ -373,7 +371,6 @@ class Lookup extends Component {
                             showCloseButton={!!searchValue}
                             onClear={this.clearInput}
                             icon={icon}
-                            closeIcon={closeIcon}
                         />
                         <Spinner
                             isVisible={isLoading}
@@ -488,8 +485,6 @@ Lookup.propTypes = {
     style: PropTypes.object,
     /** The icon to show when search is empty. */
     icon: PropTypes.node,
-    /** The icon to show when value is not empty. */
-    closeIcon: PropTypes.node,
 };
 
 Lookup.defaultProps = {
@@ -514,7 +509,6 @@ Lookup.defaultProps = {
     onSearch: () => {},
     debounce: false,
     icon: <SearchIcon />,
-    closeIcon: <CloseIcon />,
 };
 
 export default withReduxForm(Lookup);

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -327,6 +327,7 @@ class Lookup extends Component {
             name,
             hideLabel,
             isLoading,
+            searchIcon,
         } = this.props;
         const { searchValue, focusedItemIndex, options } = this.state;
         const chipOnDelete = disabled || readOnly ? undefined : this.handleRemoveValue;
@@ -365,7 +366,11 @@ class Lookup extends Component {
 
                 <RenderIf isTrue={!currentValue}>
                     <div className="rainbow-lookup_input-container" ref={this.innerContainerRef}>
-                        <RightElement showCloseButton={!!searchValue} onClear={this.clearInput} />
+                        <RightElement
+                            showCloseButton={!!searchValue}
+                            onClear={this.clearInput}
+                            searchIcon={searchIcon}
+                        />
                         <Spinner
                             isVisible={isLoading}
                             className="rainbow-lookup_spinner"
@@ -477,6 +482,8 @@ Lookup.propTypes = {
     className: PropTypes.string,
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
+    /** The icon to show when search is empty element. */
+    searchIcon: PropTypes.object,
 };
 
 Lookup.defaultProps = {

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -482,7 +482,7 @@ Lookup.propTypes = {
     className: PropTypes.string,
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
-    /** The icon to show when search is empty element. */
+    /** The icon to show when search is empty. */
     searchIcon: PropTypes.object,
 };
 
@@ -507,6 +507,7 @@ Lookup.defaultProps = {
     options: undefined,
     onSearch: () => {},
     debounce: false,
+    searchIcon: undefined,
 };
 
 export default withReduxForm(Lookup);

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -372,7 +372,7 @@ class Lookup extends Component {
                         <RightElement
                             showCloseButton={!!searchValue}
                             onClear={this.clearInput}
-                            searchIcon={icon}
+                            icon={icon}
                             closeIcon={closeIcon}
                         />
                         <Spinner
@@ -487,9 +487,9 @@ Lookup.propTypes = {
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
     /** The icon to show when search is empty. */
-    icon: PropTypes.object,
+    icon: PropTypes.node,
     /** The icon to show when value is not empty. */
-    closeIcon: PropTypes.object,
+    closeIcon: PropTypes.node,
 };
 
 Lookup.defaultProps = {

--- a/src/components/Lookup/rightElement.js
+++ b/src/components/Lookup/rightElement.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import SearchIcon from './icons/searchIcon';
 import ButtonIcon from '../ButtonIcon';
 import CloseIcon from './icons/closeIcon';
+import RenderIf from '../RenderIf';
 
-export default function RightElement({ showCloseButton, onClear, searchIcon }) {
+export default function RightElement({ showCloseButton, onClear, closeIcon, searchIcon }) {
     if (showCloseButton) {
         return (
             <span className="rainbow-lookup_input-close-button-container">
@@ -13,23 +13,29 @@ export default function RightElement({ showCloseButton, onClear, searchIcon }) {
                     size="small"
                     title="close"
                     tabIndex={-1}
-                    icon={<CloseIcon />}
+                    icon={closeIcon || <CloseIcon />}
                     onClick={onClear}
                 />
             </span>
         );
     }
-    return <span className="rainbow-lookup_input-icon">{searchIcon}</span>;
+    return (
+        <RenderIf isTrue={searchIcon}>
+            <span className="rainbow-lookup_input-icon">{searchIcon}</span>
+        </RenderIf>
+    );
 }
 
 RightElement.propTypes = {
     searchIcon: PropTypes.node,
+    closeIcon: PropTypes.node,
     showCloseButton: PropTypes.bool,
     onClear: PropTypes.func,
 };
 
 RightElement.defaultProps = {
-    searchIcon: <SearchIcon />,
+    searchIcon: undefined,
+    closeIcon: undefined,
     showCloseButton: false,
     onClear: () => {},
 };

--- a/src/components/Lookup/rightElement.js
+++ b/src/components/Lookup/rightElement.js
@@ -4,7 +4,7 @@ import ButtonIcon from '../ButtonIcon';
 import CloseIcon from './icons/closeIcon';
 import SearchIcon from './icons/searchIcon';
 
-export default function RightElement({ showCloseButton, onClear, closeIcon, searchIcon }) {
+export default function RightElement({ showCloseButton, onClear, closeIcon, icon }) {
     if (showCloseButton) {
         return (
             <span className="rainbow-lookup_input-close-button-container">
@@ -19,18 +19,18 @@ export default function RightElement({ showCloseButton, onClear, closeIcon, sear
             </span>
         );
     }
-    return <span className="rainbow-lookup_input-icon">{searchIcon || <SearchIcon />}</span>;
+    return <span className="rainbow-lookup_input-icon">{icon || <SearchIcon />}</span>;
 }
 
 RightElement.propTypes = {
-    searchIcon: PropTypes.node,
+    icon: PropTypes.node,
     closeIcon: PropTypes.node,
     showCloseButton: PropTypes.bool,
     onClear: PropTypes.func,
 };
 
 RightElement.defaultProps = {
-    searchIcon: undefined,
+    icon: undefined,
     closeIcon: undefined,
     showCloseButton: false,
     onClear: () => {},

--- a/src/components/Lookup/rightElement.js
+++ b/src/components/Lookup/rightElement.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ButtonIcon from '../ButtonIcon';
 import CloseIcon from './icons/closeIcon';
-import RenderIf from '../RenderIf';
+import SearchIcon from './icons/searchIcon';
 
 export default function RightElement({ showCloseButton, onClear, closeIcon, searchIcon }) {
     if (showCloseButton) {
@@ -19,11 +19,7 @@ export default function RightElement({ showCloseButton, onClear, closeIcon, sear
             </span>
         );
     }
-    return (
-        <RenderIf isTrue={searchIcon}>
-            <span className="rainbow-lookup_input-icon">{searchIcon}</span>
-        </RenderIf>
-    );
+    return <span className="rainbow-lookup_input-icon">{searchIcon || <SearchIcon />}</span>;
 }
 
 RightElement.propTypes = {

--- a/src/components/Lookup/rightElement.js
+++ b/src/components/Lookup/rightElement.js
@@ -4,7 +4,7 @@ import SearchIcon from './icons/searchIcon';
 import ButtonIcon from '../ButtonIcon';
 import CloseIcon from './icons/closeIcon';
 
-export default function RightElement({ showCloseButton, onClear }) {
+export default function RightElement({ showCloseButton, onClear, searchIcon }) {
     if (showCloseButton) {
         return (
             <span className="rainbow-lookup_input-close-button-container">
@@ -19,15 +19,17 @@ export default function RightElement({ showCloseButton, onClear }) {
             </span>
         );
     }
-    return <span className="rainbow-lookup_input-icon">{<SearchIcon />}</span>;
+    return <span className="rainbow-lookup_input-icon">{searchIcon}</span>;
 }
 
 RightElement.propTypes = {
+    searchIcon: PropTypes.node,
     showCloseButton: PropTypes.bool,
     onClear: PropTypes.func,
 };
 
 RightElement.defaultProps = {
+    searchIcon: <SearchIcon />,
     showCloseButton: false,
     onClear: () => {},
 };

--- a/src/components/Lookup/rightElement.js
+++ b/src/components/Lookup/rightElement.js
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ButtonIcon from '../ButtonIcon';
 import CloseIcon from './icons/closeIcon';
-import SearchIcon from './icons/searchIcon';
 
-export default function RightElement({ showCloseButton, onClear, closeIcon, icon }) {
+export default function RightElement({ showCloseButton, onClear, icon }) {
     if (showCloseButton) {
         return (
             <span className="rainbow-lookup_input-close-button-container">
@@ -13,25 +12,23 @@ export default function RightElement({ showCloseButton, onClear, closeIcon, icon
                     size="small"
                     title="close"
                     tabIndex={-1}
-                    icon={closeIcon || <CloseIcon />}
+                    icon={<CloseIcon />}
                     onClick={onClear}
                 />
             </span>
         );
     }
-    return <span className="rainbow-lookup_input-icon">{icon || <SearchIcon />}</span>;
+    return <span className="rainbow-lookup_input-icon">{icon}</span>;
 }
 
 RightElement.propTypes = {
     icon: PropTypes.node,
-    closeIcon: PropTypes.node,
     showCloseButton: PropTypes.bool,
     onClear: PropTypes.func,
 };
 
 RightElement.defaultProps = {
     icon: undefined,
-    closeIcon: undefined,
     showCloseButton: false,
     onClear: () => {},
 };


### PR DESCRIPTION
feat: #775 

Changes proposed in this PR:
- add `searchIcon` prop to make component more customizable


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
