### PR TITLE
fix: fix onFocus and onBlur events in Lookup

### DIFF
--- a/src/components/Lookup/__test__/lookup.spec.js
+++ b/src/components/Lookup/__test__/lookup.spec.js
@@ -347,4 +347,11 @@ describe('<Lookup />', () => {
         });
         expect(stopPropagationMockFn).not.toHaveBeenCalled();
     });
+    it('should fire onBlur with null', () => {
+        const onBlurMockFn = jest.fn();
+        const component = mount(<Lookup label="custom label" onBlur={onBlurMockFn} />);
+        component.find('input').simulate('focus');
+        component.find('input').simulate('blur');
+        expect(onBlurMockFn).toHaveBeenCalledWith(null);
+    });
 });

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -49,6 +49,7 @@ class Lookup extends Component {
         this.handleChange = this.handleChange.bind(this);
         this.handleFocus = this.handleFocus.bind(this);
         this.handleRemoveValue = this.handleRemoveValue.bind(this);
+        this.handleBlur = this.handleBlur.bind(this);
 
         this.handleHover = this.handleHover.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
@@ -134,10 +135,17 @@ class Lookup extends Component {
         this.fireSearch(value);
     }
 
-    handleFocus(event) {
-        const { onFocus } = this.props;
+    handleFocus() {
+        const { onFocus, value } = this.props;
         this.openMenu();
-        onFocus(event);
+        const eventValue = value || null;
+        onFocus(eventValue);
+    }
+
+    handleBlur() {
+        const { onBlur, value } = this.props;
+        const eventValue = value || null;
+        onBlur(eventValue);
     }
 
     handleRemoveValue() {
@@ -320,7 +328,6 @@ class Lookup extends Component {
             disabled,
             readOnly,
             tabIndex,
-            onBlur,
             onClick,
             required,
             id,
@@ -383,7 +390,7 @@ class Lookup extends Component {
                             onChange={this.handleSearch}
                             tabIndex={tabIndex}
                             onFocus={this.handleFocus}
-                            onBlur={onBlur}
+                            onBlur={this.handleBlur}
                             onClick={onClick}
                             disabled={disabled}
                             readOnly={readOnly}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #773 

Changes proposed in this PR:
- change onBlur and onFocus to not send search input native event


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
