### PR TITLE
fix: fix onRowSelection fired when set data and selectedRow after Tab…

### DIFF
--- a/src/components/Table/__test__/table.spec.js
+++ b/src/components/Table/__test__/table.spec.js
@@ -1121,4 +1121,18 @@ describe('<Table />', () => {
             '9012zxcvbn': true,
         });
     });
+    it('should not fire onRowSelection when set data and selectedRows after mount the component', () => {
+        const onRowSelectionMockFn = jest.fn();
+        const component = mount(
+            <Table data={[]} showCheckboxColumn onRowSelection={onRowSelectionMockFn} keyField="id">
+                <Column field="name" header="Name" />
+                <Column field="id" header="ID" />
+            </Table>,
+        );
+        component.setProps({
+            data: tableData,
+            selectedRows: ['1234qwerty', '5678asdfgh', '9012zxcvbn'],
+        });
+        expect(onRowSelectionMockFn).not.toHaveBeenCalled();
+    });
 });

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -118,6 +118,11 @@ export default class Table extends Component {
             minColumnWidth,
             maxColumnWidth,
         });
+        const isNotSameMaxRowSelection = prevMaxRowSelection !== maxRowSelection;
+        const isNotSameData = data !== prevData;
+        if (isNotSameMaxRowSelection || isNotSameData) {
+            this.updateRows();
+        }
         if (isNotSameColumns(prevColumns, currentColumns)) {
             this.updateColumnsAndTableWidth(currentColumns);
         }
@@ -138,11 +143,6 @@ export default class Table extends Component {
                 onRowSelection(this.getSelectedRows(updatedRows));
                 this.updateRows();
             }
-        }
-        const isNotSameMaxRowSelection = prevMaxRowSelection !== maxRowSelection;
-        const isNotSameData = data !== prevData;
-        if (isNotSameMaxRowSelection || isNotSameData) {
-            this.updateRows();
         }
     }
 


### PR DESCRIPTION
…le component is mounted

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #782 

Changes proposed in this PR:
- fix onRowSelection fired when set data and selectedRow after Table is mounted


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
