### PR TITLE
fix: use checkbox when only one row

### DIFF
--- a/src/components/Table/__test__/table.spec.js
+++ b/src/components/Table/__test__/table.spec.js
@@ -1135,4 +1135,14 @@ describe('<Table />', () => {
         });
         expect(onRowSelectionMockFn).not.toHaveBeenCalled();
     });
+    it('should set input type to "checkbox" when there is only one row', () => {
+        const singleData = [{ name: 'John Doe' }];
+        const component = mount(
+            <Table keyField="id" data={singleData} showCheckboxColumn>
+                <Column field="name" header="Name" />
+            </Table>,
+        );
+        const input = component.find('Input[label="select row"]').find('input');
+        expect(input.prop('type')).toBe('checkbox');
+    });
 });

--- a/src/components/Table/helpers/rows/__test__/getRowSelectionInputType.spec.js
+++ b/src/components/Table/helpers/rows/__test__/getRowSelectionInputType.spec.js
@@ -11,4 +11,14 @@ describe('getRowSelectionInputType', () => {
             expect(getRowSelectionInputType(value)).toBe('checkbox');
         });
     });
+    it('should return "checkbox" when maxRowSelection passed is 1 and rows length is 1', () => {
+        const maxRowSelection = 1;
+        const rowsLength = 1;
+        expect(getRowSelectionInputType(maxRowSelection, rowsLength)).toBe('checkbox');
+    });
+    it('should return "checkbox" when maxRowSelection passed is greater than 1 and rows length is 1', () => {
+        const maxRowSelection = 3;
+        const rowsLength = 1;
+        expect(getRowSelectionInputType(maxRowSelection, rowsLength)).toBe('checkbox');
+    });
 });

--- a/src/components/Table/helpers/rows/getRowSelectionInputType.js
+++ b/src/components/Table/helpers/rows/getRowSelectionInputType.js
@@ -1,5 +1,5 @@
-export default function getRowSelectionInputType(maxRowSelection) {
-    if (maxRowSelection === 1) {
+export default function getRowSelectionInputType(maxRowSelection, rowsLength) {
+    if (maxRowSelection === 1 && rowsLength !== 1) {
         return 'radio';
     }
     return 'checkbox';

--- a/src/components/Table/helpers/rows/getRows.js
+++ b/src/components/Table/helpers/rows/getRows.js
@@ -12,7 +12,7 @@ function getKey(row, keyField) {
 
 export default function getRows(params = {}) {
     const { rows = [], maxRowSelection, keyField, selectedRowsKeys } = params;
-    const inputType = getRowSelectionInputType(maxRowSelection);
+    const inputType = getRowSelectionInputType(maxRowSelection, rows.length);
     return rows.map(row => {
         const key = getKey(row, keyField);
         return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #784 

Changes proposed in this PR:
- use checkbox when only one row


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
