### PR TITLE
feat: add prop size to Lookup component

### DIFF
--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -325,6 +325,7 @@ class Lookup extends Component {
             style,
             label,
             error,
+            size,
             placeholder,
             disabled,
             readOnly,
@@ -416,6 +417,7 @@ class Lookup extends Component {
                                     onHoverOption={this.handleHover}
                                     itemHeight={OPTION_HEIGHT}
                                     ref={this.menuRef}
+                                    size={size}
                                 />
                             </div>
                         </RenderIf>
@@ -470,6 +472,12 @@ Lookup.propTypes = {
     disabled: PropTypes.bool,
     /** Specifies that the Lookup is read-only. This value defaults to false. */
     readOnly: PropTypes.bool,
+    /** The icon that appears in the Lookup when the input search is empty.
+     * If not passed by default a search icon will be showed. */
+    icon: PropTypes.node,
+    /** The size of the Lookup menu. Options include small, medium, or large.
+     * This value defaults to medium. */
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
     /** Specifies the tab order of an element (when the tab button is used for navigating). */
     tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /** The action triggered for every key stroke when the customer is typing in the input.
@@ -490,9 +498,6 @@ Lookup.propTypes = {
     className: PropTypes.string,
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
-    /** The icon that appears in the Lookup when the input search is empty.
-     * If not passed by default a search icon will be showed. */
-    icon: PropTypes.node,
 };
 
 Lookup.defaultProps = {
@@ -503,6 +508,8 @@ Lookup.defaultProps = {
     error: null,
     disabled: false,
     readOnly: false,
+    icon: <SearchIcon />,
+    size: 'medium',
     onChange: () => {},
     tabIndex: undefined,
     onClick: () => {},
@@ -516,7 +523,6 @@ Lookup.defaultProps = {
     options: undefined,
     onSearch: () => {},
     debounce: false,
-    icon: <SearchIcon />,
 };
 
 export default withReduxForm(Lookup);

--- a/src/components/Lookup/options/index.js
+++ b/src/components/Lookup/options/index.js
@@ -49,7 +49,7 @@ export default class Options extends React.PureComponent {
 
     getMaxHeight() {
         const { size } = this.props;
-        return sizeMap[size] || 256;
+        return sizeMap[size] || sizeMap.medium;
     }
 
     getRef() {

--- a/src/components/Lookup/options/index.js
+++ b/src/components/Lookup/options/index.js
@@ -68,7 +68,6 @@ export default class Options extends React.PureComponent {
             onHoverOption,
             focusedItemIndex,
             itemHeight,
-            size,
         } = this.props;
 
         if (items.length === 0) {
@@ -95,7 +94,6 @@ export default class Options extends React.PureComponent {
                 className="rainbow-lookup_options-container"
                 style={resultContainerStyles}
                 ref={this.containerRef}
-                size={size}
             >
                 <MenuItems
                     items={items}

--- a/src/components/Lookup/options/index.js
+++ b/src/components/Lookup/options/index.js
@@ -35,10 +35,21 @@ function MenuItems(props) {
     });
 }
 
+const sizeMap = {
+    small: 160,
+    medium: 256,
+    large: 400,
+};
+
 export default class Options extends React.PureComponent {
     constructor(props) {
         super(props);
         this.containerRef = React.createRef();
+    }
+
+    getMaxHeight() {
+        const { size } = this.props;
+        return sizeMap[size] || 256;
     }
 
     getRef() {
@@ -57,6 +68,7 @@ export default class Options extends React.PureComponent {
             onHoverOption,
             focusedItemIndex,
             itemHeight,
+            size,
         } = this.props;
 
         if (items.length === 0) {
@@ -75,7 +87,7 @@ export default class Options extends React.PureComponent {
 
         const resultContainerStyles = {
             height: itemHeight * items.length + 17,
-            maxHeight: 256,
+            maxHeight: this.getMaxHeight(),
         };
 
         return (
@@ -83,6 +95,7 @@ export default class Options extends React.PureComponent {
                 className="rainbow-lookup_options-container"
                 style={resultContainerStyles}
                 ref={this.containerRef}
+                size={size}
             >
                 <MenuItems
                     items={items}
@@ -102,6 +115,7 @@ Options.propTypes = {
     onHoverOption: PropTypes.func,
     focusedItemIndex: PropTypes.number,
     itemHeight: PropTypes.number.isRequired,
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 Options.defaultProps = {
@@ -110,4 +124,5 @@ Options.defaultProps = {
     onSelectOption: () => {},
     onHoverOption: () => {},
     focusedItemIndex: undefined,
+    size: 'medium',
 };

--- a/src/components/Lookup/options/styles.css
+++ b/src/components/Lookup/options/styles.css
@@ -9,7 +9,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 32px 16px;
+  padding: 24px 16px;
   letter-spacing: normal;
   line-height: 1.43;
   text-align: center; }
@@ -19,7 +19,7 @@
   width: 36px; }
 
 .rainbow-lookup_options-empty-message {
-  margin-top: 14px;
+  margin-top: 12px;
   width: 90%; }
 
 .rainbow-lookup_options-empty-message_match-value {

--- a/src/components/Lookup/options/styles.scss
+++ b/src/components/Lookup/options/styles.scss
@@ -12,7 +12,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 32px 16px;
+    padding: 24px 16px;
     letter-spacing: normal;
     line-height: 1.43;
     text-align: center;
@@ -24,7 +24,7 @@
 }
 
 .rainbow-lookup_options-empty-message {
-    margin-top: 14px;
+    margin-top: 12px;
     width: 90%;
 }
 

--- a/src/components/Lookup/styles.css
+++ b/src/components/Lookup/styles.css
@@ -147,7 +147,7 @@
 
 .rainbow-lookup_input-close-button-container {
   height: 100%;
-  right: 0.8rem;
+  right: 0.5rem;
   position: absolute;
   line-height: 1;
   z-index: 2;

--- a/src/components/Lookup/styles.scss
+++ b/src/components/Lookup/styles.scss
@@ -203,7 +203,7 @@
 
 .rainbow-lookup_input-close-button-container {
     height: 100%;
-    right: 0.8rem;
+    right: 0.5rem;
     position: absolute;
     line-height: 1;
     z-index: 2;

--- a/src/components/RadioGroup/styles.css
+++ b/src/components/RadioGroup/styles.css
@@ -7,7 +7,8 @@
   color: #576574;
   font-size: 0.875rem;
   margin-right: 0.75rem;
-  margin-bottom: 0.25rem; }
+  margin-bottom: 0.25rem;
+  width: 100%; }
 
 .rainbow-radio-group_inner-container .rainbow-radio-group_radio {
   display: block; }

--- a/src/components/RadioGroup/styles.scss
+++ b/src/components/RadioGroup/styles.scss
@@ -22,6 +22,7 @@
     font-size: $font-size-text-medium;
     margin-right: $margin-small;
     margin-bottom: $margin-xx-small;
+    width: 100%;
 }
 
 .rainbow-radio-group_inner-container {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #821 

Changes proposed in this PR:
- add prop size to the `lookup` component


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
