### PR TITLE
fix: keyboard navigation in Lookup when use other size than medium

### DIFF
--- a/integration/specs/Lookup/lookup-3.spec.js
+++ b/integration/specs/Lookup/lookup-3.spec.js
@@ -1,0 +1,42 @@
+const PageLookup = require('../../../src/components/Lookup/pageObject');
+const { ARROW_DOWN_KEY, ARROW_UP_KEY } = require('../../constants');
+
+const LOOKUP = '#lookup-3';
+
+describe('Lookup small with icon and description example', () => {
+    beforeAll(() => {
+        browser.url('/#!/Lookup/3');
+    });
+    beforeEach(() => {
+        browser.refresh();
+        const component = $(LOOKUP);
+        component.waitForExist();
+    });
+
+    it('should scroll down to see the next option focused when initially is not visible', () => {
+        const lookup = new PageLookup(LOOKUP);
+        lookup.click();
+        lookup.setQuery('a');
+        lookup.waitUntilOpen();
+        const option5 = lookup.getOption(4);
+        expect(option5.isVisible()).toBe(false);
+        lookup.getOption(2).hover();
+        browser.keys(ARROW_DOWN_KEY);
+        browser.keys(ARROW_DOWN_KEY);
+        expect(option5.isVisible()).toBe(true);
+    });
+    it('should scroll up to see the first option', () => {
+        const lookup = new PageLookup(LOOKUP);
+        lookup.click();
+        lookup.setQuery('a');
+        lookup.waitUntilOpen();
+        const option1 = lookup.getOption(0);
+        lookup.getOption(2).hover();
+        browser.keys(ARROW_DOWN_KEY);
+        browser.keys(ARROW_DOWN_KEY);
+        lookup.getOption(2).hover();
+        browser.keys(ARROW_UP_KEY);
+        browser.keys(ARROW_UP_KEY);
+        expect(option1.isVisible()).toBe(true);
+    });
+});

--- a/src/components/Lookup/helpers/isOptionVisible.js
+++ b/src/components/Lookup/helpers/isOptionVisible.js
@@ -1,6 +1,5 @@
 export default function isOptionVisible(el, container) {
     const { top: elTop, bottom: elBottom } = el.getBoundingClientRect();
     const { top: containerTop, bottom: containerBottom } = container.getBoundingClientRect();
-    const isVisible = (elTop >= containerTop) && (elBottom <= containerBottom);
-    return isVisible;
+    return elTop >= containerTop && elBottom <= containerBottom;
 }

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -22,6 +22,11 @@ import SearchIcon from './icons/searchIcon';
 import './styles.css';
 
 const OPTION_HEIGHT = 48;
+const visibleOptionsMap = {
+    small: 3,
+    medium: 5,
+    large: 8,
+};
 
 /**
  * A Lookup is an autocomplete text input that will search against a database object,
@@ -249,11 +254,13 @@ class Lookup extends Component {
 
     scrollUp(prevFocusedIndex) {
         const { options } = this.state;
+        const { size } = this.props;
         const menu = this.menuRef.current.getRef();
         const prevIndex = prevFocusedIndex >= 0 ? prevFocusedIndex : 0;
         const prevFocusedOption = menu.childNodes[prevIndex];
+        const visibleOptionsAmount = visibleOptionsMap[size] || visibleOptionsMap.medium;
 
-        if (options.length > 5 && !isOptionVisible(prevFocusedOption, menu)) {
+        if (options.length > visibleOptionsAmount && !isOptionVisible(prevFocusedOption, menu)) {
             this.menuRef.current.scrollTo(OPTION_HEIGHT * prevIndex);
         }
     }
@@ -276,11 +283,15 @@ class Lookup extends Component {
 
     scrollDown(nextFocusedIndex) {
         const { options } = this.state;
+        const { size } = this.props;
         const menu = this.menuRef.current.getRef();
         const nextFocusedOption = menu.childNodes[nextFocusedIndex];
+        const visibleOptionsAmount = visibleOptionsMap[size] || visibleOptionsMap.medium;
 
-        if (options.length > 5 && !isOptionVisible(nextFocusedOption, menu)) {
-            this.menuRef.current.scrollTo(OPTION_HEIGHT * (nextFocusedIndex - 4));
+        if (options.length > visibleOptionsAmount && !isOptionVisible(nextFocusedOption, menu)) {
+            this.menuRef.current.scrollTo(
+                OPTION_HEIGHT * (nextFocusedIndex - (visibleOptionsAmount - 1)),
+            );
         }
     }
 

--- a/src/components/Lookup/options/__test__/options.spec.js
+++ b/src/components/Lookup/options/__test__/options.spec.js
@@ -11,13 +11,33 @@ describe('<Options />', () => {
         const component = mount(<Options items={[{}]} />);
         expect(component.find('ul').exists()).toBe(true);
     });
-    it('should pass the right height to the ul element', () => {
+    it('should set the right height to the ul element', () => {
         const values = [[{}], [{}, {}], [{}, {}, {}, {}], [{}, {}, {}, {}, {}, {}]];
         const expects = [65, 113, 209, 305];
         values.forEach((items, index) => {
             const component = mount(<Options items={items} itemHeight={48} />);
             expect(component.find('ul').prop('style').height).toBe(expects[index]);
         });
+    });
+    it('should set the right max height to the ul element when size is not passed', () => {
+        const component = mount(<Options items={[{}]} />);
+        expect(component.find('ul').prop('style').maxHeight).toBe(256);
+    });
+    it('should set the right max height to the ul element when size is small', () => {
+        const component = mount(<Options items={[{}]} size="small" />);
+        expect(component.find('ul').prop('style').maxHeight).toBe(160);
+    });
+    it('should set the right max height to the ul element when size is medium', () => {
+        const component = mount(<Options items={[{}]} size="medium" />);
+        expect(component.find('ul').prop('style').maxHeight).toBe(256);
+    });
+    it('should set the right max height to the ul element when size is large', () => {
+        const component = mount(<Options items={[{}]} size="large" />);
+        expect(component.find('ul').prop('style').maxHeight).toBe(400);
+    });
+    it('should set the right max height to the ul element when a wrong size is passed', () => {
+        const component = mount(<Options items={[{}]} size="wrong size" />);
+        expect(component.find('ul').prop('style').maxHeight).toBe(256);
     });
     it('should render the amount of menu items passed as items', () => {
         const component = mount(<Options items={[{}, {}, {}]} />);

--- a/src/components/Lookup/readme.md
+++ b/src/components/Lookup/readme.md
@@ -60,7 +60,7 @@
             onSearch={search} />
     </div>
 
-##### Lookup with icon and description:
+##### Lookup small with icon and description:
 
     const { FontAwesomeIcon } = require('@fortawesome/react-fontawesome');
     const { faBuilding } = require('@fortawesome/free-regular-svg-icons');
@@ -177,8 +177,10 @@
 
     <div className="rainbow-p-vertical_large rainbow-p-horizontal_xx-large rainbow-m-horizontal_xx-large">
         <Lookup
+            id="lookup-3"
             label="Lookup Label"
             placeholder="Find"
+            size="small"
             options={state.options}
             value={state.option}
             onChange={(option) => setState({ option })}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

Changes proposed in this PR:
- fix keyboard navigation in Lookup when use other size than medium


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
