### PR TITLE
fix: call stopPropagation when toggle menu in PrimitiveMenu

### DIFF
--- a/src/components/PrimitiveMenu/index.js
+++ b/src/components/PrimitiveMenu/index.js
@@ -211,7 +211,8 @@ export default class PrimitiveMenu extends Component {
         });
     }
 
-    toggleMenu() {
+    toggleMenu(event) {
+        event.stopPropagation();
         const { isOpen } = this.state;
         if (isOpen) {
             return this.closeMenu();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #

Changes proposed in this PR:
- call stopPropagation when toggle menu in PrimitiveMenu

[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
