### PR TITLE
fix: remove stop propagation in primitive menu

### DIFF
--- a/src/components/PrimitiveMenu/index.js
+++ b/src/components/PrimitiveMenu/index.js
@@ -21,7 +21,6 @@ export default class PrimitiveMenu extends Component {
         this.handleClick = this.handleClick.bind(this);
         this.closeMenu = this.closeMenu.bind(this);
         this.hoverChild = this.hoverChild.bind(this);
-        this.handleTriggerClick = this.handleTriggerClick.bind(this);
 
         this.registerChild = this.registerChild.bind(this);
         this.unregisterChild = this.unregisterChild.bind(this);
@@ -220,15 +219,6 @@ export default class PrimitiveMenu extends Component {
         return this.openMenu();
     }
 
-    handleTriggerClick(event) {
-        event.stopPropagation();
-        const { isOpen } = this.state;
-        if (isOpen) {
-            return this.closeMenu();
-        }
-        return this.openMenu();
-    }
-
     /**
      * Sets focus on the element.
      * @public
@@ -286,7 +276,7 @@ export default class PrimitiveMenu extends Component {
                     ariaExpanded={isOpen}
                     ariaHaspopup
                     assistiveText={assistiveText}
-                    onClick={this.handleTriggerClick}
+                    onClick={this.toggleMenu}
                     ref={this.triggerRef}
                 />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

Changes proposed in this PR:
- remove stop propagation in primitive menu


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
